### PR TITLE
Added z-index to glimpse-nowrap in shell.css

### DIFF
--- a/source/glimpse.render.shell.css
+++ b/source/glimpse.render.shell.css
@@ -854,6 +854,7 @@ div.glimpse-ellipsis {
     -moz-transform: translatez(0);
     -ms-transform: translatez(0);
     -o-transform: translatez(0);
+    z-index: 99999999;
 }
 
 .glimpse-nowrap .glimpse-icon {


### PR DESCRIPTION
added z-index with a very large number to glimpse.render.shell.css to class ".glimpse-nowrap" to solve hidding of glimpse behind other parts of the page.